### PR TITLE
Support for milliseconds

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,14 +33,14 @@ class KeywordQueryEventListener(EventListener):
             ))
             return RenderResultListAction(items)
 
-        eventValue = event.get_argument()
+        timestamp = int(event.get_argument())
         description = "From seconds"
-        if len(eventValue) > 11:
-            eventValue = eventValue[0:10]
-            description = "From submultiple of a second"
+        if timestamp > 99999999999:
+            timestamp = timestamp/1000
+            description = "From milliseconds"
 
-        utcDt = datetime.datetime.utcfromtimestamp(int(eventValue))
-        localDt = datetime.datetime.fromtimestamp(int(eventValue))
+        utcDt = datetime.datetime.utcfromtimestamp(timestamp)
+        localDt = datetime.datetime.fromtimestamp(timestamp)
 
         formattedLocalDt = localDt.strftime('%Y-%m-%d %H:%M:%S')
         formattedUtcDt = utcDt.strftime('%Y-%m-%d %H:%M:%S')

--- a/main.py
+++ b/main.py
@@ -33,14 +33,21 @@ class KeywordQueryEventListener(EventListener):
             ))
             return RenderResultListAction(items)
 
-        utcDt = datetime.datetime.utcfromtimestamp(int(event.get_argument()))
-        localDt = datetime.datetime.fromtimestamp(int(event.get_argument()))
+        eventValue = event.get_argument()
+        description = "From seconds"
+        if len(eventValue) > 11:
+            eventValue = eventValue[0:10]
+            description = "From submultiple of a second"
+
+        utcDt = datetime.datetime.utcfromtimestamp(int(eventValue))
+        localDt = datetime.datetime.fromtimestamp(int(eventValue))
 
         formattedLocalDt = localDt.strftime('%Y-%m-%d %H:%M:%S')
         formattedUtcDt = utcDt.strftime('%Y-%m-%d %H:%M:%S')
         items.append(ExtensionResultItem(
             icon='images/icon.png',
             name="Local Time: " + formattedLocalDt,
+            description=description,
             highlightable=False,
             on_enter=CopyToClipboardAction(formattedLocalDt)
         ))
@@ -48,6 +55,7 @@ class KeywordQueryEventListener(EventListener):
         items.append(ExtensionResultItem(
             icon='images/icon.png',
             name="UTC Time: " + formattedUtcDt,
+            description=description,
             highlightable=False,
             on_enter=CopyToClipboardAction(formattedUtcDt)
         ))


### PR DESCRIPTION
This PR adds support for milliseconds. It assumes that it the integer value is larger than 99999999999, it is in milliseconds. That seems to be what https://www.unixtimestamp.com/ does as well (but it also support other submultiples of a second). Since it only displays seconds, it rounds the value down to nearest second.

It also shows if the value is interpreted as seconds or milliseconds in the description.
![image](https://user-images.githubusercontent.com/590967/214582131-f14210bf-4c2e-4760-95c1-c8109f8b9944.png)

Closes #5 
Closes #6